### PR TITLE
x86: Fix void pointer arithmetic

### DIFF
--- a/src/x86/ffiw64.c
+++ b/src/x86/ffiw64.c
@@ -190,7 +190,7 @@ ffi_prep_closure_loc (ffi_closure* closure,
     /* nopl  (%rax) */
     0x0f, 0x1f, 0x00
   };
-  void *tramp = closure->tramp;
+  unsigned char *tramp = closure->tramp;
 
   if (cif->abi != FFI_WIN64)
     return FFI_BAD_ABI;


### PR DESCRIPTION
ANSI C forbids `void` pointer arithmetic.