### PR TITLE
Fix expr error in Solaris 10 when using gcc.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -269,11 +269,13 @@ if test "x$GCC" = "xyes"; then
   	if $CC $CFLAGS -c -fpic -fexceptions -o conftest.o conftest.c > /dev/null 2>&1; then
 	    objdump -h conftest.o > conftest.dump 2>&1
 	    libffi_eh_frame_line=`grep -n eh_frame conftest.dump | cut -d: -f 1`
-	    libffi_test_line=`expr $libffi_eh_frame_line + 1`p
-	    sed -n $libffi_test_line conftest.dump > conftest.line
-  	    if grep READONLY conftest.line > /dev/null; then
-  		libffi_cv_ro_eh_frame=yes
-  	    fi
+	    if test "x$libffi_eh_frame_line" != "x"; then
+	        libffi_test_line=`expr $libffi_eh_frame_line + 1`p
+	        sed -n $libffi_test_line conftest.dump > conftest.line
+	        if grep READONLY conftest.line > /dev/null; then
+	            libffi_cv_ro_eh_frame=yes
+	        fi
+	    fi
   	fi
   	rm -f conftest.*
       ])


### PR DESCRIPTION
The following error is outputted when configuring `libffi` in Solaris 10 amd64 for GCC: 
```
checking whether .eh_frame section should be read-only... expr: syntax error
no
```
This introduces a test for a non-empty result when grep'ing the `objdump` output for `eh_frame`. 

Side note: in Solaris there is no `objdump` and it seems `elfdump -c` could be used instead of `objdump -h`. If that would be case, then the `grep` command should check for `" .eh_frame"` instead of `eh_frame` in `conftest.dump`, otherwise a second instance of `eh_frame` will  be matched in that file in the string `rela.eh_frame`.

Please review. Thanks!