### PR TITLE
Support closures on ARM64 iOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -215,7 +215,7 @@ fi
 
 FFI_EXEC_TRAMPOLINE_TABLE=0
 case "$target" in
-     *arm*-apple-darwin*)
+     *arm*-apple-darwin* | aarch64-apple-darwin*)
        FFI_EXEC_TRAMPOLINE_TABLE=1
        AC_DEFINE(FFI_EXEC_TRAMPOLINE_TABLE, 1,
                  [Cannot use PROT_EXEC on this target, so, we revert to

--- a/src/aarch64/ffitarget.h
+++ b/src/aarch64/ffitarget.h
@@ -42,7 +42,13 @@ typedef enum ffi_abi
 /* ---- Definitions for closures ----------------------------------------- */
 
 #define FFI_CLOSURES 1
+#if defined (__APPLE__)
+#define FFI_TRAMPOLINE_SIZE 20
+#define FFI_TRAMPOLINE_CLOSURE_OFFSET 16
+#else
 #define FFI_TRAMPOLINE_SIZE 24
+#define FFI_TRAMPOLINE_CLOSURE_OFFSET FFI_TRAMPOLINE_SIZE
+#endif
 #define FFI_NATIVE_RAW_API 0
 
 /* ---- Internal ---- */

--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -248,8 +248,8 @@ CNAME(ffi_closure_SYSV):
 	stp     x6, x7, [sp, #16 + 16*N_V_ARG_REG + 48]
 
 	/* Load ffi_closure_inner arguments.  */
-	ldp	x0, x1, [x17, #FFI_TRAMPOLINE_SIZE]	/* load cif, fn */
-	ldr	x2, [x17, #FFI_TRAMPOLINE_SIZE+16]	/* load user_data */
+	ldp	x0, x1, [x17, #FFI_TRAMPOLINE_CLOSURE_OFFSET]	/* load cif, fn */
+	ldr	x2, [x17, #FFI_TRAMPOLINE_CLOSURE_OFFSET+16]	/* load user_data */
 .Ldo_closure:
 	add	x3, sp, #16				/* load context */
 	add	x4, sp, #ffi_closure_SYSV_FS		/* load stack */
@@ -341,6 +341,25 @@ CNAME(ffi_closure_SYSV):
 	.type	CNAME(ffi_closure_SYSV), #function
 	.hidden	CNAME(ffi_closure_SYSV)
 	.size	CNAME(ffi_closure_SYSV), . - CNAME(ffi_closure_SYSV)
+#endif
+
+#if FFI_EXEC_TRAMPOLINE_TABLE
+    .align 12
+CNAME(ffi_closure_trampoline_table_page):
+    .rept 16384 / FFI_TRAMPOLINE_SIZE
+    adr	x17, -16384
+    adr	x16, -16380
+    ldr x16, [x16]
+    ldr x17, [x17]
+    br	x16
+    .endr
+    
+    .globl CNAME(ffi_closure_trampoline_table_page)
+    #ifdef __ELF__
+    	.type	CNAME(ffi_closure_trampoline_table_page), #function
+    	.hidden	CNAME(ffi_closure_trampoline_table_page)
+    	.size	CNAME(ffi_closure_trampoline_table_page), . - CNAME(ffi_closure_trampoline_table_page)
+    #endif
 #endif
 
 #ifdef FFI_GO_CLOSURES

--- a/src/aarch64/sysv.S
+++ b/src/aarch64/sysv.S
@@ -134,17 +134,17 @@ CNAME(ffi_call_SYSV):
 	ret
 7:	brk	#1000			/* UNUSED */
 	ret
-8:	st4	{ v0.s-v3.s }[0], [x3]	/* S4 */
+8:	st4	{ v0.s, v1.s, v2.s, v3.s }[0], [x3]	/* S4 */
 	ret
-9:	st3	{ v0.s-v2.s }[0], [x3]	/* S3 */
+9:	st3	{ v0.s, v1.s, v2.s }[0], [x3]	/* S3 */
 	ret
 10:	stp	s0, s1, [x3]		/* S2 */
 	ret
 11:	str	s0, [x3]		/* S1 */
 	ret
-12:	st4	{ v0.d-v3.d }[0], [x3]	/* D4 */
+12:	st4	{ v0.d, v1.d, v2.d, v3.d }[0], [x3]	/* D4 */
 	ret
-13:	st3	{ v0.d-v2.d }[0], [x3]	/* D3 */
+13:	st3	{ v0.d, v1.d, v2.d }[0], [x3]	/* D3 */
 	ret
 14:	stp	d0, d1, [x3]		/* D2 */
 	ret


### PR DESCRIPTION
This patch copies the arm implementation of the iOS-friendly trampoline table closures to aarch64. While functional, there are two things I don't like about it:

1. There is a lot of copy/pasta in ffi.c based on arm/ffi.c. Ideally I'd like to refactor it and keep the code in a shared location for the two targets but I'm unsure as to what's a good home for it. Perhaps closures.c?
2. The actual trampoline table page code in sysv.S is the product of a single evening spent with the ARM instruction set reference manual - I don't like how bloated it is compared to the arm trampoline but I don't know if it can be implemented in a better way. I'd like to ask someone more proficient in aarch64 for a shove in the right direction.

I want to make this patch better and then upstream it, but I need some help on the above issues.