### PR TITLE
document that there must be ntotalargs types

### DIFF
--- a/doc/libffi.texi
+++ b/doc/libffi.texi
@@ -161,7 +161,7 @@ same as for @code{ffi_prep_cif} except that:
 variadic arguments.  It must be greater than zero.
 
 @var{ntotalargs} the total number of arguments, including variadic
-and fixed arguments.
+and fixed arguments.  @var{argtypes} must have this many elements.
 
 Note that, different cif's must be prepped for calls to the same
 function when different numbers of arguments are passed.


### PR DESCRIPTION
I wasn't sure whether a call to `ffi_prep_cif_var` needed argument types for the variadic args (not sure how I could be confused about this, but I was).  I ended up looking at the test suite to see, so I thought a small patch to the docs might help future users.