### PR TITLE
Fix dejagnu test support for --tool_opts

### DIFF
--- a/testsuite/lib/libffi.exp
+++ b/testsuite/lib/libffi.exp
@@ -182,7 +182,7 @@ proc libffi_target_compile { source dest type options } {
     # TOOL_OPTIONS must come first, so that it doesn't override testcase
     # specific options.
     if [info exists TOOL_OPTIONS] {
-	lappend  options [concat "additional_flags=$TOOL_OPTIONS" $options];
+	lappend  options "additional_flags=$TOOL_OPTIONS"
     }
 
     # search for ffi_mips.h in srcdir, too


### PR DESCRIPTION
Right now it concatenates it with the existing options and then appends it to that list, fix it to simply append it as is, same as it is done with the other variables.

Tested by running the following command which includes gcc options:
```
  $ make check RUNTESTFLAGS="--tool_opts '-Werror'"
```

Without this patch, all the tests fail. With it, the test succeed. Inspecting the logs shows that `-Werror` was indeed used when compiling the test sources.

@atgreen 