### PR TITLE
mark ffi_prep_closure as deprecated

### DIFF
--- a/include/ffi.h.in
+++ b/include/ffi.h.in
@@ -337,7 +337,8 @@ ffi_status
 ffi_prep_closure (ffi_closure*,
 		  ffi_cif *,
 		  void (*fun)(ffi_cif*,void*,void**,void*),
-		  void *user_data);
+		  void *user_data)
+  __attribute__((deprecated ("use ffi_prep_closure_loc instead")));
 
 ffi_status
 ffi_prep_closure_loc (ffi_closure*,


### PR DESCRIPTION
This marks ffi_prep_closure as deprecated.  This will give an error to gcc users; and I think is safe due to an earlier define of __attribute__ in this file for other compilers.