### PR TITLE
ffi_prep_types is internal-only

### DIFF
--- a/include/ffi.h.in
+++ b/include/ffi.h.in
@@ -231,11 +231,6 @@ typedef struct {
 #endif
 } ffi_cif;
 
-#if @HAVE_LONG_DOUBLE_VARIANT@
-/* Used to adjust size/alignment of ffi types.  */
-void ffi_prep_types (ffi_abi abi);
-#endif
-
 /* Used internally, but overridden by some architectures */
 ffi_status ffi_prep_cif_core(ffi_cif *cif,
 			     ffi_abi abi,

--- a/include/ffi_common.h
+++ b/include/ffi_common.h
@@ -82,6 +82,11 @@ ffi_status ffi_prep_cif_machdep(ffi_cif *cif);
 ffi_status ffi_prep_cif_machdep_var(ffi_cif *cif,
 	 unsigned int nfixedargs, unsigned int ntotalargs);
 
+#if HAVE_LONG_DOUBLE_VARIANT
+/* Used to adjust size/alignment of ffi types.  */
+void ffi_prep_types (ffi_abi abi);
+#endif
+
 /* Extended cif, used in callback from assembly routine */
 typedef struct
 {


### PR DESCRIPTION
I think ffi_prep_types is only for internal use, and so this patch moves its declaration to ffi_common.h.