### PR TITLE
remove FFI_TYPE typedef

### DIFF
--- a/include/ffi.h.in
+++ b/include/ffi.h.in
@@ -217,8 +217,6 @@ typedef enum {
   FFI_BAD_ABI
 } ffi_status;
 
-typedef unsigned FFI_TYPE;
-
 typedef struct {
   ffi_abi abi;
   unsigned nargs;


### PR DESCRIPTION
ffi.h.in defines a typedef, `FFI_TYPE`, that is neither used nor documented by libffi.  So this patch simply removes it as being extraneous.