### PR TITLE
Don't clobber safeseh for msvcc.sh -clang-cl in 32-bit mode

### DIFF
--- a/msvcc.sh
+++ b/msvcc.sh
@@ -70,7 +70,6 @@ do
     ;;
     -clang-cl)
       cl="clang-cl"
-      safeseh=
       shift 1
     ;;
     -O0)


### PR DESCRIPTION
The commit fb25cd0 went a bit too far and removed safeseh
when -clang-cl was passed, but that's only needed in x86-64
which is already handled by the -m64 flag.

I discovered this when building Firefox x86 with clang-cl.